### PR TITLE
fix nested reply branch

### DIFF
--- a/post/nested-reply/schema.js
+++ b/post/nested-reply/schema.js
@@ -10,7 +10,7 @@ module.exports = {
       pattern: '^post$'
     },
     root: { $ref: '#/definitions/root' },
-    branch: { $ref: '#/definitions/messageId' },
+    branch: { $ref: '#/definitions/branch' },
     fork: { $ref: '#/definitions/messageId' },
     text: { type: 'string' },
 


### PR DESCRIPTION
@mixmix hi, i'm pretty sure a nested reply (sub-thread) may have multiple branch messages, so here's a pull request to fix that.

example message: %BUTTdXGkNCFZjeYU4/GVKv1TRfR79lfG7LlgZmaN9mg=.sha256